### PR TITLE
Fix the CI by pinning the older compiler version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,7 @@ jobs:
         default: true
         ldproxy: false
         buildtargets: esp32
+        version: 1.71.0.0
     - uses: Swatinem/rust-cache@v1
     - name: Build
       run: cargo build --verbose


### PR DESCRIPTION
There seems to be a regression with `type_alias_impl_trait` feature - let's use an older version of the compiler for now.